### PR TITLE
fix: transact after setting env

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ fn main() {
     let mut evm: EVM<CacheDB<EmptyDB>> = EVM::new();
     evm.database(db);
 
-    let result = evm.transact().unwrap();
-
     // fill in missing bits of env struc
     // change that to whatever caller you want to be
     evm.env.tx.caller = B160::from_slice(&[0; 20]);
@@ -49,6 +47,8 @@ fn main() {
     evm.env.tx.data = Bytes::new();
     // transaction value in wei
     evm.env.tx.value = U256::try_from(0).unwrap();
+
+    let result = evm.transact().unwrap();
 
     match result.result {
         revm::primitives::ExecutionResult::Success {


### PR DESCRIPTION
We must execute the `transact` after setting the revm environment